### PR TITLE
Add hex string types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/CodeChain-io/codechain-rpc-go
 
 go 1.12
+
+require github.com/ethereum/go-ethereum v1.9.6

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ethereum/go-ethereum v1.9.6 h1:EacwxMGKZezZi+m3in0Tlyk0veDQgnfZ9BjQqHAaQLM=
+github.com/ethereum/go-ethereum v1.9.6/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=

--- a/primitives/primitives.go
+++ b/primitives/primitives.go
@@ -1,0 +1,118 @@
+package primitives
+
+import (
+	"encoding/hex"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Handles 128-bit data
+type H128 [16]byte
+
+// Handles 160-bit data
+type H160 [20]byte
+
+// Handles 256-bit data
+type H256 [32]byte
+
+// Handles 512-bit data
+type H512 [64]byte
+
+func NewH128Zero() H128 {
+	var zero H128 = [16]byte{}
+	return zero
+}
+
+func (h H128) Cmp(g H128) bool {
+	return h == g
+}
+
+func (h H128) ToString() string {
+	return string(h[:])
+}
+
+func (h H128) RlpBytes() []byte {
+	x, _ := rlp.EncodeToBytes(h)
+	return x
+}
+
+func (h H128) ToJSON() string {
+	var test []byte = make([]byte, 32)
+	innerArrOfH := [16]byte(h)
+	hex.Encode(test, innerArrOfH[:])
+	return "0x" + string(test)
+}
+
+func NewH160Zero() H160 {
+	var zero H160 = [20]byte{}
+	return zero
+}
+
+func (h H160) Cmp(g H160) bool {
+	return h == g
+}
+
+func (h H160) ToString() string {
+	return string(h[:])
+}
+
+func (h H160) RlpBytes() []byte {
+	x, _ := rlp.EncodeToBytes(h)
+	return x
+}
+
+func (h H160) ToJSON() string {
+	var test []byte = make([]byte, 40)
+	innerArrOfH := [20]byte(h)
+	hex.Encode(test, innerArrOfH[:])
+	return "0x" + string(test)
+}
+
+func NewH256Zero() H256 {
+	var zero H256 = [32]byte{}
+	return zero
+}
+
+func (h H256) Cmp(g H256) bool {
+	return h == g
+}
+
+func (h H256) ToString() string {
+	return string(h[:])
+}
+
+func (h H256) RlpBytes() []byte {
+	x, _ := rlp.EncodeToBytes(h)
+	return x
+}
+
+func (h H256) ToJSON() string {
+	var test []byte = make([]byte, 64)
+	innerArrOfH := [32]byte(h)
+	hex.Encode(test, innerArrOfH[:])
+	return "0x" + string(test)
+}
+
+func NewH512Zero() H512 {
+	var zero H512 = [64]byte{}
+	return zero
+}
+
+func (h H512) Cmp(g H512) bool {
+	return h == g
+}
+
+func (h H512) ToString() string {
+	return string(h[:])
+}
+
+func (h H512) RlpBytes() []byte {
+	x, _ := rlp.EncodeToBytes(h)
+	return x
+}
+
+func (h H512) ToJSON() string {
+	var test []byte = make([]byte, 128)
+	innerArrOfH := [64]byte(h)
+	hex.Encode(test, innerArrOfH[:])
+	return "0x" + string(test)
+}

--- a/primitives/primitives_test.go
+++ b/primitives/primitives_test.go
@@ -1,0 +1,20 @@
+package primitives
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestH128(t *testing.T) {
+	a := NewH128Zero()
+	b := NewH128Zero()
+	c := H128([16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+	d := NewH512Zero()
+	fmt.Println(d)
+	fmt.Println(d.ToJSON())
+	fmt.Println(a.Cmp(b))
+	fmt.Println(c.Cmp(b))
+	fmt.Println(a.ToString())
+	fmt.Println(a.RlpBytes())
+	fmt.Println(a.ToJSON())
+}


### PR DESCRIPTION
output `go test` in `./primitives` is

```
[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
true
false

[144 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
0x00000000000000000000000000000000
PASS
ok      github.com/CodeChain-io/codechain-rpc-go/primitives     0.005s
```