### PR TITLE
Fix a non-exported methods to exported

### DIFF
--- a/account.go
+++ b/account.go
@@ -31,21 +31,21 @@ func (acc *Account) Unlock(account string, passphrase string, duration int) {
 	acc.rpcClient.call(callInterface{method: method}, nil, account, passphrase, duration)
 }
 
-func (acc *Account) sign(message string, account string, passphrase string) string {
+func (acc *Account) Sign(message string, account string, passphrase string) string {
 	const method = "account_sign"
 	var signature string
 	acc.rpcClient.call(callInterface{method: method}, &signature, message, account, passphrase)
 	return signature
 }
 
-func (acc *Account) sendTransaction(transaction UnsignedTransaction, account string, passphrase string) interface{} {
+func (acc *Account) SendTransaction(transaction UnsignedTransaction, account string, passphrase string) interface{} {
 	const method = "account_sendTransaction"
 	var result interface{}
 	acc.rpcClient.call(callInterface{method: method}, &result, transaction, account, passphrase)
 	return result
 }
 
-func (acc *Account) changePassword(account string, oldPassphrase string, newPassphrase string) {
+func (acc *Account) ChangePassword(account string, oldPassphrase string, newPassphrase string) {
 	const method = "account_changePassword"
 	acc.rpcClient.call(callInterface{method: method}, nil, account, oldPassphrase, newPassphrase)
 }


### PR DESCRIPTION
This PR fixes some methods—defined on `Account` type—to exported. Since method names begins with a lowercase could not accessible from outside the `rpc` package.

---
ref. [Go Language Specification: Exported identifiers](https://golang.org/ref/spec#Exported_identifiers)
>An identifier may be exported to permit access to it from another package. An identifier is exported if both:
>
> 1. the first character of the identifier's name is a Unicode upper case letter (Unicode class "Lu"); and
> 2. the identifier is declared in the package block or it is a field name or method name.