### PR TITLE
Fix lint errors

### DIFF
--- a/crypto/bech32.go
+++ b/crypto/bech32.go
@@ -1,4 +1,4 @@
-// bech32 implementations are based on codechain-primitives-js
+// Package crypto bech32 implementations are based on codechain-primitives-js
 package crypto
 
 import (
@@ -7,7 +7,7 @@ import (
 
 const alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
-func alphabet_map(c rune) int {
+func alphabetMap(c rune) int {
 	for k, v := range alphabet {
 		if c == v {
 			return k
@@ -70,7 +70,7 @@ func bech32Decode(str string, prefix string) (words []byte) {
 	var chk = prefixChk(prefix)
 	wordChars := str[len(prefix):]
 	for i, c := range wordChars {
-		v := alphabet_map(c)
+		v := alphabetMap(c)
 		chk = polymodeStep(chk) ^ int(v)
 
 		if i+6 >= len(wordChars) {

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -11,7 +11,7 @@ func Blake256(data string) string {
 	s, _ := hex.DecodeString(data)
 	b.Write(s)
 	bs := b.Sum(nil)
-	var result []byte = make([]byte, 64)
+	var result = make([]byte, 64)
 	hex.Encode(result, bs[:])
 	return string(result)
 }
@@ -21,7 +21,7 @@ func Blake256WithKey(data string, key []byte) string {
 	s, _ := hex.DecodeString(data)
 	b.Write(s)
 	bs := b.Sum(nil)
-	var result []byte = make([]byte, 64)
+	var result = make([]byte, 64)
 	hex.Encode(result, bs[:])
 	return string(result)
 }
@@ -31,7 +31,7 @@ func Blake128(data string) string {
 	s, _ := hex.DecodeString(data)
 	b.Write(s)
 	bs := b.Sum(nil)
-	var result []byte = make([]byte, 32)
+	var result = make([]byte, 32)
 	hex.Encode(result, bs[:])
 	return string(result)
 }
@@ -41,7 +41,7 @@ func Blake128WithKey(data string, key []byte) string {
 	s, _ := hex.DecodeString(data)
 	b.Write(s)
 	bs := b.Sum(nil)
-	var result []byte = make([]byte, 32)
+	var result = make([]byte, 32)
 	hex.Encode(result, bs[:])
 	return string(result)
 }
@@ -51,7 +51,7 @@ func Blake160(data string) string {
 	s, _ := hex.DecodeString(data)
 	b.Write(s)
 	bs := b.Sum(nil)
-	var result []byte = make([]byte, 40)
+	var result = make([]byte, 40)
 	hex.Encode(result, bs[:])
 	return string(result)
 }
@@ -61,7 +61,7 @@ func Blake160WithKey(data string, key []byte) string {
 	s, _ := hex.DecodeString(data)
 	b.Write(s)
 	bs := b.Sum(nil)
-	var result []byte = make([]byte, 40)
+	var result = make([]byte, 40)
 	hex.Encode(result, bs[:])
 	return string(result)
 }
@@ -71,7 +71,7 @@ func Ripemd160(data string) string {
 	s, _ := hex.DecodeString(data)
 	r.Write(s)
 	rs := r.Sum(nil)
-	var result []byte = make([]byte, 40)
+	var result = make([]byte, 40)
 	hex.Encode(result, rs[:])
 	return string(result)
 }


### PR DESCRIPTION
Changed package comment.
Removed underscores.
And removed the [redundant type declarations](https://github.com/golang/lint/issues/292).